### PR TITLE
upload multiple cpp files

### DIFF
--- a/rpc-client-test/src/main/java/com/antgroup/tugraph/TuGraphDbRpcClientTest.java
+++ b/rpc-client-test/src/main/java/com/antgroup/tugraph/TuGraphDbRpcClientTest.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 public class TuGraphDbRpcClientTest {
     static Logger log = LoggerFactory.getLogger(TuGraphDbRpcClientTest.class);
@@ -35,6 +36,16 @@ public class TuGraphDbRpcClientTest {
             result = client.loadProcedure("./scan_graph.so", "CPP", "scan_graph", "SO", "test scan_graph", true,
                     "v1", "default");
             log.info("loadProcedure : " + result);
+
+            String[] multi_files = {
+                    "../../test/test_procedures/multi_files.cpp",
+                    "../../test/test_procedures/multi_files.h",
+                    "../../test/test_procedures/multi_files_core.cpp"
+            };
+            result = client.loadProcedure(multi_files, "CPP", "multi_file", "CPP", "test sortstr", true,
+                    "v1", "default");
+            log.info("loadProcedure : " + result);
+            assert (result);
         } catch (IOException e) {
             log.info("catch IOException : " + e.getMessage());
         } catch (Exception e) {
@@ -48,7 +59,7 @@ public class TuGraphDbRpcClientTest {
             String result = client.listProcedures("CPP", "any", "default");
             log.info("testListProcedure: " + result);
             JSONArray jsonArray = JSONArray.parseArray(result);
-            assert (jsonArray.size() == 2);
+            assert (jsonArray.size() == 3);
         } catch (TuGraphDbRpcException e) {
             log.info("catch TuGraphDbRpcException : " + e.getMessage());
         }

--- a/rpc-client/src/main/proto/lgraph.proto
+++ b/rpc-client/src/main/proto/lgraph.proto
@@ -574,9 +574,10 @@ message LoadPluginRequest {
 
     required string name = 1;
     required bool read_only = 2;
-    required bytes code = 3;
+    repeated bytes code = 3;
     optional string desc = 4;
     optional CodeType code_type = 5;
+    repeated string file_name = 6;
 };
 
 message LoadPluginResponse {};


### PR DESCRIPTION
在browser中CPP plugin支持上传多个插件，修改了proto文件
code： bytes -> repeated bytes
新增 file_name: repeated bytes
新增loadProcedure重载，参数sourceFiles: String[]，支持上传多个文件